### PR TITLE
PVS fix, vmt indexes enum, etc.

### DIFF
--- a/csgo/features/animations/anim.cpp
+++ b/csgo/features/animations/anim.cpp
@@ -29,7 +29,7 @@ void c_animations::OnEntityCreated( C_BaseEntity *ent ) {
 
 			m_track[ index ].m_index = index;
 			m_track[ index ].m_vmt = std::make_unique< c_vmt >( ent );
-			m_track[ index ].m_vmt->hook_method( 193, animations::DoExtraBonesProcessing );
+			m_track[ index ].m_vmt->hook_method( hook::idx::DO_EXTRA_BONE_PROC, animations::DoExtraBonesProcessing );
 			m_track[ index ].m_hooked = true;
 
 			break;

--- a/csgo/features/autowall/autowall.cpp
+++ b/csgo/features/autowall/autowall.cpp
@@ -221,15 +221,16 @@ void c_autowall::clip_trace( const vec3_t &src, vec3_t &end, trace_t *tr, C_Base
 	}
 }
 
-bool c_autowall::think( const vec3_t &position, C_CSPlayer *entity, const int mindmg, const bool run_bullet_pen ) {
-	auto local = C_CSPlayer::get_local( );
-	if( !entity || !local )
+bool c_autowall::think( C_CSPlayer *from_ent, C_CSPlayer *to_ent, const vec3_t &position, int mindmg, bool run_bullet_pen ) {
+	if( !from_ent )
+		from_ent = C_CSPlayer::get_local( );
+	if ( !from_ent )
 		return false;
 
-	if( entity->IsDormant( ) )
+	if( to_ent->IsDormant( ) )
 		return false;
 
-	C_BaseCombatWeapon *weapon = local->get_active_weapon( );
+	C_BaseCombatWeapon *weapon = from_ent->get_active_weapon( );
 	if( !weapon )
 		return false;
 
@@ -239,7 +240,7 @@ bool c_autowall::think( const vec3_t &position, C_CSPlayer *entity, const int mi
 
 	m_autowall_dmg = static_cast< float >( weapon_info->damage );
 
-	vec3_t start = local->eye_pos( );
+	vec3_t start = from_ent->eye_pos( );
 	vec3_t direction( position - start );
 	direction.Normalize( );
 
@@ -247,14 +248,14 @@ bool c_autowall::think( const vec3_t &position, C_CSPlayer *entity, const int mi
 	float trace_length = 0.f;
 
 	trace_t trace;
-	CTraceFilterSkipEntity filter( local );
+	CTraceFilterSkipEntity filter( from_ent );
 
 	while( m_autowall_dmg > 0.f ) {
 		const float trace_length_remaining = weapon_info->range - trace_length;
 		vec3_t end = start + direction * trace_length_remaining;
 
 		g_csgo.m_engine_trace->TraceRay( Ray_t{ start, end }, MASK_SHOT_HULL | CONTENTS_HITBOX, &filter, &trace );
-		clip_trace( end + direction * 40.f, start, &trace, entity );
+		clip_trace( end + direction * 40.f, start, &trace, to_ent );
 
 		if( trace.fraction == 1.f )
 			break;
@@ -262,8 +263,8 @@ bool c_autowall::think( const vec3_t &position, C_CSPlayer *entity, const int mi
 		trace_length += trace.fraction * trace_length_remaining;
 		m_autowall_dmg *= std::pow( weapon_info->range_modifier, trace_length / 500 );
 
-		if( trace.hitgroup > HITGROUP_GENERIC && trace.hitgroup <= HITGROUP_RIGHTLEG && trace.hit_entity != nullptr && entity == trace.hit_entity ) {
-			scale_damage( trace.hitgroup, entity, weapon_info->armor_ratio, m_autowall_dmg );
+		if( trace.hitgroup > HITGROUP_GENERIC && trace.hitgroup <= HITGROUP_RIGHTLEG && trace.hit_entity != nullptr && to_ent == trace.hit_entity ) {
+			scale_damage( trace.hitgroup, to_ent, weapon_info->armor_ratio, m_autowall_dmg );
 			return m_autowall_dmg >= mindmg;
 		}
 

--- a/csgo/features/autowall/autowall.h
+++ b/csgo/features/autowall/autowall.h
@@ -34,7 +34,7 @@ public:
 
 	static float hitgroup_dmg( int hitgroup );
 	static void scale_damage( int hitgroup, C_CSPlayer *ent, float weapon_armor_ratio, float &current_damage );
-	bool think( const vec3_t &position, C_CSPlayer *entity, int mindmg, bool run_bullet_pen );
+	bool think( C_CSPlayer *from_ent, C_CSPlayer *to_ent, const vec3_t &position, int mindmg, bool run_bullet_pen );
 };
 
 extern c_autowall g_autowall;

--- a/csgo/features/ragebot/ragebot.cpp
+++ b/csgo/features/ragebot/ragebot.cpp
@@ -115,7 +115,7 @@ void c_ragebot::select_target( ) {
 				if( g_vars.visuals.extra.points )
 					g_csgo.m_debug_overlay->AddBoxOverlay( p, vec3_t( -0.7f, -0.7f, -0.7f ), vec3_t( 0.7f, 0.7f, 0.7f ), vec3_t( 0.f, 0.f, 0.f ), 0, 255, 0, 100, g_csgo.m_global_vars->m_interval_per_tick * 2 );
 
-				if ( g_autowall.think( p, e, g_vars.rage.min_dmg, true ) ) {
+				if ( g_autowall.think( C_CSPlayer::get_local( ), e, p, g_vars.rage.min_dmg, true ) ) {
 					if( g_autowall.m_autowall_dmg > player_best_damage ) {
 						player_best_damage = g_autowall.m_autowall_dmg;
 						player_best_point = p;

--- a/csgo/hooking/hooks/CreateMove.cpp
+++ b/csgo/hooking/hooks/CreateMove.cpp
@@ -7,7 +7,7 @@
 #include "../../features/engine_pred/engine_pred.h"
 
 bool __fastcall hook::CreateMove( uintptr_t ecx, uintptr_t edx, float flInputSampleTime, CUserCmd *cmd ) {
-	static bool ret = g_hooks.m_clientmode.get_old_method< fn::CreateMove_t >( 24 )( ecx, flInputSampleTime, cmd );
+	static bool ret = g_hooks.m_clientmode.get_old_method< fn::CreateMove_t >( hook::idx::CREATE_MOVE )( ecx, flInputSampleTime, cmd );
 
 	g_cl.m_sendpacket = true;
 

--- a/csgo/hooking/hooks/DoExtraBonesProcessing.cpp
+++ b/csgo/hooking/hooks/DoExtraBonesProcessing.cpp
@@ -10,7 +10,7 @@ void __fastcall animations::DoExtraBonesProcessing( uintptr_t ecx, uintptr_t edx
 		backup = animstate->on_ground;
 		animstate->on_ground = false;
 	}
-	g_anim.m_track[ e->GetIndex( ) ].m_vmt->get_old_method< fn::DoExtraBonesProcessing_t >( 193 )( ecx, hdr, pos, q, matrix, bone_list, context );
+	g_anim.m_track[ e->GetIndex( ) ].m_vmt->get_old_method< fn::DoExtraBonesProcessing_t >( hook::idx::DO_EXTRA_BONE_PROC )( ecx, hdr, pos, q, matrix, bone_list, context );
 	if( animstate ){
 		animstate->on_ground = backup;
 	}

--- a/csgo/hooking/hooks/DrawModelExecute.cpp
+++ b/csgo/hooking/hooks/DrawModelExecute.cpp
@@ -2,7 +2,7 @@
 #include "../../features/chams/chams.h"
 
 void __fastcall hook::DrawModelExecute( uintptr_t ecx, uintptr_t edx, IMatRenderContext *ctx, void *state, const ModelRenderInfo_t &pInfo, matrix3x4_t *pCustomBoneToWorld ){
-	static auto original = g_hooks.m_modelrender.get_old_method< fn::DrawModelExecute_t >( 21 );
+	static auto original = g_hooks.m_modelrender.get_old_method< fn::DrawModelExecute_t >( hook::idx::DRAW_MODEL_EXECUTE );
 	if ( g_chams.on_dme( ctx, state, pInfo, pCustomBoneToWorld ) )
 		original( ecx, ctx, state, pInfo, pCustomBoneToWorld );
 

--- a/csgo/hooking/hooks/FrameStageNotify.cpp
+++ b/csgo/hooking/hooks/FrameStageNotify.cpp
@@ -7,7 +7,6 @@
 
 void __fastcall hook::FrameStageNotify( uintptr_t ecx, uintptr_t edx, ClientFrameStage_t curstage ) {
 
-
 	g_misc.no_smoke( curstage );
 
 	if( g_cl.m_should_update_materials ) {
@@ -15,20 +14,37 @@ void __fastcall hook::FrameStageNotify( uintptr_t ecx, uintptr_t edx, ClientFram
 		g_misc.transparent_props( );
 	}
 
-	auto in_thirdperson = g_csgo.m_input->m_fCameraInThirdPerson;
+	switch ( curstage ) {
+		case FRAME_RENDER_START: {
+			auto in_thirdperson = g_csgo.m_input->m_fCameraInThirdPerson;
 
-	if( in_thirdperson && g_vars.antiaim.enabled && curstage == FRAME_RENDER_START )
-		g_csgo.m_prediction->SetLocalViewangles( g_antiaim.m_real );
+			if ( in_thirdperson && g_vars.antiaim.enabled )
+				g_csgo.m_prediction->SetLocalViewangles( g_antiaim.m_real );
+		}
+	}
 
-	g_hooks.m_client.get_old_method< fn::FrameStageNotify_t >( 37 )( ecx, curstage );
+	g_hooks.m_client.get_old_method< fn::FrameStageNotify_t >( hook::idx::FRAME_STAGE_NOTIFY )( ecx, curstage );
 
-	if( curstage == FRAME_NET_UPDATE_POSTDATAUPDATE_START ) {
-		auto local = C_CSPlayer::get_local( );
-		if( local ) {
-			if( g_vars.visuals.misc.no_flash )
-				local->flash_alpha( ) = 0.f;
-			else
-				local->flash_alpha( ) = 255.f;
+	switch ( curstage ) {
+		case FRAME_RENDER_START: {
+			for ( int i = 1; i <= g_csgo.m_global_vars->m_max_clients; ++i ) {
+				auto e = g_csgo.m_entity_list->Get< C_CSPlayer >( i );
+
+				if ( !e )
+					continue;
+
+				*( int* )( ( uintptr_t )e + 0xA30 ) = g_csgo.m_global_vars->m_frame_count;
+				*( int* )( ( uintptr_t )e + 0xA28 ) = 0;
+			}
+		}
+		case FRAME_NET_UPDATE_POSTDATAUPDATE_START: {
+			auto local = C_CSPlayer::get_local( );
+			if ( local ) {
+				if ( g_vars.visuals.misc.no_flash )
+					local->flash_alpha( ) = 0.f;
+				else
+					local->flash_alpha( ) = 255.f;
+			}
 		}
 	}
 }

--- a/csgo/hooking/hooks/GetMaterial.cpp
+++ b/csgo/hooking/hooks/GetMaterial.cpp
@@ -3,7 +3,7 @@
 IMaterial * __fastcall hook::GetMaterial( uintptr_t ecx, uintptr_t edx, const char *material_name, const char *texture_group_name, bool complain,
 	const char *complain_prefix ) {
 
-	static auto original = g_hooks.m_materialsystem.get_old_method< fn::GetMaterial_t >( 84 );
+	static auto original = g_hooks.m_materialsystem.get_old_method< fn::GetMaterial_t >( hook::idx::GET_MATERIAL );
 
 	if( !strcmp( material_name, "dev/scope_bluroverlay" ) && g_vars.visuals.misc.remove_scope ){
 		static auto clear = original( ecx, "dev/clearalpha", nullptr, complain, complain_prefix );

--- a/csgo/hooking/hooks/LevelInitPostEntity.cpp
+++ b/csgo/hooking/hooks/LevelInitPostEntity.cpp
@@ -3,7 +3,7 @@
 #include "../../features/ragebot/ragebot.h"
 
 void __fastcall hook::LevelInitPostEntity( uintptr_t ecx, uintptr_t edx ) {
-	g_hooks.m_client.get_old_method< fn::LevelInitPostEntity_t >( 7 )( ecx );
+	g_hooks.m_client.get_old_method< fn::LevelInitPostEntity_t >( hook::idx::LEVEL_INIT_POST_ENTITY )( ecx );
 	
 	g_cl.m_local  = C_CSPlayer::get_local( );
 	g_cl.m_should_update_materials = true;

--- a/csgo/hooking/hooks/LevelShutdown.cpp
+++ b/csgo/hooking/hooks/LevelShutdown.cpp
@@ -2,6 +2,6 @@
 #include "../../features/animations/anim.h"
 
 void __fastcall hook::LevelShutdown( uintptr_t ecx, uintptr_t edx ) {
-	g_hooks.m_client.get_old_method< fn::LevelShutdown_t >( 8 )( ecx );
+	g_hooks.m_client.get_old_method< fn::LevelShutdown_t >( hook::idx::LEVEL_SHUTDOWN )( ecx );
 	g_cl.m_local = nullptr;
 }

--- a/csgo/hooking/hooks/LockCursor.cpp
+++ b/csgo/hooking/hooks/LockCursor.cpp
@@ -7,5 +7,5 @@ void __stdcall hook::LockCursor( ) {
 			return;
 		}
 	}
-	g_hooks.m_surface.get_old_method< fn::LockCursor_t >( 67 )( g_csgo.m_surface );
+	g_hooks.m_surface.get_old_method< fn::LockCursor_t >( hook::idx::LOCK_CURSOR )( g_csgo.m_surface );
 }

--- a/csgo/hooking/hooks/OverrideView.cpp
+++ b/csgo/hooking/hooks/OverrideView.cpp
@@ -16,5 +16,5 @@ void __fastcall hook::OverrideView( uintptr_t ecx, uintptr_t edx, CViewSetup *pS
 
 	g_misc.thirdperson( );
 
-	g_hooks.m_clientmode.get_old_method< fn::OverrideView_t >( 18 )( ecx, pSetup );
+	g_hooks.m_clientmode.get_old_method< fn::OverrideView_t >( hook::idx::OVERRIDE_VIEW )( ecx, pSetup );
 }

--- a/csgo/hooking/hooks/RenderSmokeOverlay.cpp
+++ b/csgo/hooking/hooks/RenderSmokeOverlay.cpp
@@ -2,6 +2,6 @@
 
 void __fastcall hook::RenderSmokeOverlay( uintptr_t ecx, uintptr_t edx, bool a1 ){
 	if( !g_vars.visuals.misc.remove_smoke ) {
-		g_hooks.m_viewrender.get_old_method< fn::RenderSmokeOverlay_t >( 41 )( ecx, a1 );
+		g_hooks.m_viewrender.get_old_method< fn::RenderSmokeOverlay_t >( hook::idx::RENDER_SMOKE_OVERLAY )( ecx, a1 );
 	}
 }

--- a/csgo/hooking/hooks/SceneEnd.cpp
+++ b/csgo/hooking/hooks/SceneEnd.cpp
@@ -3,7 +3,7 @@
 #include "../../features/visuals/visuals.h"
 
 void __fastcall hook::SceneEnd( uintptr_t ecx, uintptr_t edx ){
-	g_hooks.m_renderview.get_old_method< fn::SceneEnd_t >( 9 )( ecx );
+	g_hooks.m_renderview.get_old_method< fn::SceneEnd_t >( hook::idx::SCENE_END )( ecx );
 
 	if( g_vars.visuals.glow )
 		g_visuals.handle_glow( );

--- a/csgo/hooking/hooks/TestHitboxes.cpp
+++ b/csgo/hooking/hooks/TestHitboxes.cpp
@@ -4,5 +4,5 @@
 bool __fastcall animations::TestHitboxes( uintptr_t ecx, uintptr_t edx, const Ray_t &ray, unsigned int fContentsMask, trace_t& tr ) {
 	auto player = reinterpret_cast<C_CSPlayer *>( ecx );
 	auto index = player->GetIndex();
-	return g_anim.m_track[ index ].m_vmt->get_old_method< fn::TestHitboxes_t >( 52 )( ecx, ray, fContentsMask, tr );
+	return g_anim.m_track[ index ].m_vmt->get_old_method< fn::TestHitboxes_t >( hook::idx::TEST_HITBOXES )( ecx, ray, fContentsMask, tr );
 }

--- a/csgo/hooking/hooks/UpdateClientSideAnimations.cpp
+++ b/csgo/hooking/hooks/UpdateClientSideAnimations.cpp
@@ -4,5 +4,5 @@
 void __fastcall animations::UpdateClientSideAnimations( uintptr_t ecx, uintptr_t edx ) {
 	auto player = reinterpret_cast<C_CSPlayer *>( ecx );
 	auto index = player->GetIndex( );
-	g_anim.m_track[ index ].m_vmt->get_old_method< fn::UpdateClientSideAnimations_t >( 219 )( ecx );
+	g_anim.m_track[ index ].m_vmt->get_old_method< fn::UpdateClientSideAnimations_t >( hook::idx::UPDATE_CLIENTSIDE_ANIM )( ecx );
 }

--- a/csgo/hooking/hooks/present.cpp
+++ b/csgo/hooking/hooks/present.cpp
@@ -41,6 +41,6 @@ HRESULT __stdcall hook::Present( IDirect3DDevice9 *device, const RECT *pSourceRe
 
 	g_renderer.end_drawing( device );
 
-	return g_hooks.m_directx.get_old_method< fn::Present_t >( 17 )( device, pSourceRect, pDestRect, hDestWindowOverride,
+	return g_hooks.m_directx.get_old_method< fn::Present_t >( hook::idx::PRESENT )( device, pSourceRect, pDestRect, hDestWindowOverride,
 	                                                           pDirtyRegion );
 }

--- a/csgo/hooking/hooks/reset.cpp
+++ b/csgo/hooking/hooks/reset.cpp
@@ -3,7 +3,7 @@
 HRESULT __stdcall hook::Reset( IDirect3DDevice9 *device, D3DPRESENT_PARAMETERS *pPresentationParameters ) {
 	g_renderer.m_instance->GetRenderer( ).PreD3DReset( );
 
-	auto ret = g_hooks.m_directx.get_old_method< fn::Reset_t >( 16 )( device, pPresentationParameters );
+	auto ret = g_hooks.m_directx.get_old_method< fn::Reset_t >( hook::idx::RESET )( device, pPresentationParameters );
 
 	g_renderer.m_instance->GetRenderer( ).PostD3DReset( );
 

--- a/csgo/hooking/manager.cpp
+++ b/csgo/hooking/manager.cpp
@@ -17,29 +17,29 @@ void c_hooks::init( ) {
 }
 
 void c_hooks::hook( ) {
-	m_directx.hook_method( 17, &hook::Present );
-	m_directx.hook_method( 16, &hook::Reset );
+	m_directx.hook_method( hook::idx::PRESENT, &hook::Present );
+	m_directx.hook_method( hook::idx::RESET, &hook::Reset );
 
-	m_clientmode.hook_method( 17, &hook::ShouldDrawFog );
-	m_clientmode.hook_method( 24, &hook::CreateMove );
-	m_clientmode.hook_method( 18, &hook::OverrideView );
+	m_clientmode.hook_method( hook::idx::SHOULD_DRAW_FOG, &hook::ShouldDrawFog );
+	m_clientmode.hook_method( hook::idx::CREATE_MOVE, &hook::CreateMove );
+	m_clientmode.hook_method( hook::idx::OVERRIDE_VIEW, &hook::OverrideView );
 	//m_clientmode.hook_method( 35, &hook::GetViewModelFOV );
 
-	m_client.hook_method( 7, &hook::LevelInitPostEntity );
-	m_client.hook_method( 8, &hook::LevelShutdown );
-	m_client.hook_method( 37, &hook::FrameStageNotify );
+	m_client.hook_method( hook::idx::LEVEL_INIT_POST_ENTITY, &hook::LevelInitPostEntity );
+	m_client.hook_method( hook::idx::LEVEL_SHUTDOWN, &hook::LevelShutdown );
+	m_client.hook_method( hook::idx::FRAME_STAGE_NOTIFY, &hook::FrameStageNotify );
 
-	m_surface.hook_method( 67, &hook::LockCursor );
+	m_surface.hook_method( hook::idx::LOCK_CURSOR, &hook::LockCursor );
 
-	m_panel.hook_method( 41, &hook::PaintTraverse );
+	m_panel.hook_method( hook::idx::PAINT_TRAVERSE, &hook::PaintTraverse );
 
-	m_modelrender.hook_method( 21, &hook::DrawModelExecute );
+	m_modelrender.hook_method( hook::idx::DRAW_MODEL_EXECUTE, &hook::DrawModelExecute );
 
-	m_renderview.hook_method( 9, hook::SceneEnd );
+	m_renderview.hook_method( hook::idx::SCENE_END, hook::SceneEnd );
 
-	m_viewrender.hook_method( 41, hook::RenderSmokeOverlay );
+	m_viewrender.hook_method( hook::idx::RENDER_SMOKE_OVERLAY, hook::RenderSmokeOverlay );
 
-	m_materialsystem.hook_method( 84, hook::GetMaterial );
+	m_materialsystem.hook_method( hook::idx::GET_MATERIAL, hook::GetMaterial );
 }
 
 

--- a/csgo/hooking/manager.h
+++ b/csgo/hooking/manager.h
@@ -31,6 +31,47 @@ namespace hook {
 
 	};
 
+	// enum for indexes for easier updating
+	enum idx : int {
+		// directx
+		RESET =					16,
+		PRESENT =				17,
+		
+		// clientmode
+		SHOULD_DRAW_FOG =		17,
+		OVERRIDE_VIEW =			18,
+		CREATE_MOVE =			24,
+		GET_VIEWMODEL_FOV =		35,
+
+		// client
+		LEVEL_INIT_POST_ENTITY = 7,
+		LEVEL_SHUTDOWN =		 8,
+		FRAME_STAGE_NOTIFY =	 37,
+
+		// surface
+		LOCK_CURSOR =			 67,
+
+		// panel
+		PAINT_TRAVERSE =		 41,
+
+		// modelrender
+		DRAW_MODEL_EXECUTE =	 21,
+
+		// renderview
+		SCENE_END =				 9,
+
+		// viewrender
+		RENDER_SMOKE_OVERLAY =	 41,
+
+		// materialsystem
+		GET_MATERIAL =			 84,
+
+		// ccsplayer
+		TEST_HITBOXES =			 52,
+		DO_EXTRA_BONE_PROC =	 193,
+		UPDATE_CLIENTSIDE_ANIM = 219,
+	};
+
 	// our funcs.
 	HRESULT __stdcall Present( IDirect3DDevice9 *device, const RECT *pSourceRect, const RECT *pDestRect,
 	                           HWND hDestWindowOverride, const RGNDATA *pDirtyRegion );

--- a/dc-csgo.vcxproj
+++ b/dc-csgo.vcxproj
@@ -46,9 +46,9 @@
     <ClCompile Include="csgo\hooking\hooks\LockCursor.cpp" />
     <ClCompile Include="csgo\hooking\hooks\OverrideView.cpp" />
     <ClCompile Include="csgo\hooking\hooks\PaintTraverse.cpp" />
-    <ClCompile Include="csgo\hooking\hooks\present.cpp" />
+    <ClCompile Include="csgo\hooking\hooks\Present.cpp" />
     <ClCompile Include="csgo\hooking\hooks\RenderSmokeOverlay.cpp" />
-    <ClCompile Include="csgo\hooking\hooks\reset.cpp" />
+    <ClCompile Include="csgo\hooking\hooks\Reset.cpp" />
     <ClCompile Include="csgo\hooking\hooks\SceneEnd.cpp" />
     <ClCompile Include="csgo\hooking\hooks\ShouldDrawFog.cpp" />
     <ClCompile Include="csgo\hooking\hooks\TestHitboxes.cpp" />

--- a/dc-csgo.vcxproj.filters
+++ b/dc-csgo.vcxproj.filters
@@ -94,12 +94,6 @@
     <ClCompile Include="csgo\dllmain.cpp">
       <Filter>dc-csgo</Filter>
     </ClCompile>
-    <ClCompile Include="csgo\hooking\hooks\present.cpp">
-      <Filter>dc-csgo\hooking\hooks</Filter>
-    </ClCompile>
-    <ClCompile Include="csgo\hooking\hooks\reset.cpp">
-      <Filter>dc-csgo\hooking\hooks</Filter>
-    </ClCompile>
     <ClCompile Include="csgo\features\visuals\visuals.cpp">
       <Filter>dc-csgo\features\visuals</Filter>
     </ClCompile>
@@ -197,6 +191,12 @@
       <Filter>dc-csgo\hooking</Filter>
     </ClCompile>
     <ClCompile Include="csgo\hooking\hooks\RenderSmokeOverlay.cpp">
+      <Filter>dc-csgo\hooking\hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="csgo\hooking\hooks\Reset.cpp">
+      <Filter>dc-csgo\hooking\hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="csgo\hooking\hooks\Present.cpp">
       <Filter>dc-csgo\hooking\hooks</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
- PVS fix for inaccurate setupbones
- VMT indexes enum for easy updating
- Renamed 2 hook files to match naming of the rest of the files
- Modified autowall to allow for autowalling of local player, will be helpful for freestanding later on
- Added switch statements for FSN stages, if statements will definitely get messy might as well add it now