### PR TITLE
Use fakelag amount as the max in adaptive fakelag

### DIFF
--- a/csgo/features/fakelag/fakelag.cpp
+++ b/csgo/features/fakelag/fakelag.cpp
@@ -16,7 +16,7 @@ void c_fakelag::think( c_user_cmd* cmd ) {
 				break;
 			}
 			case 1: { // Adaptive
-				choke = std::min< int >( static_cast< int >( std::ceilf( 64 / ( g_cl.m_local->velocity( ).length( ) * g_csgo.m_global_vars->m_interval_per_tick ) ) ), 14 );
+				choke = std::min< int >( static_cast< int >( std::ceilf( 64 / ( g_cl.m_local->velocity( ).length( ) * g_csgo.m_global_vars->m_interval_per_tick ) ) ), g_vars.misc.fakelag.amount + 1 );
 				break;
 			}
 		}


### PR DESCRIPTION
Unsure if it should be `amount + 1` or just `amount` so feel free to tell me and I'll gladly change it.

Anyways I think that it's better to use the fakelag amount as the maximum amount that the adaptive fakelag will go, just makes more sense (atleast to me).