### PR TITLE
fix crash on WM_KEYDOWN

### DIFF
--- a/deadcell/input/input.hpp
+++ b/deadcell/input/input.hpp
@@ -4,7 +4,7 @@ class input_mngr : public OSHGui::Input::Input {
 private:
 	HWND                    m_window_handle;
 	WNDPROC                 m_original_wndproc;
-	std::array< bool, 255 > m_key_pressed;
+	std::array< bool, 256 > m_key_pressed;
 	OSHGui::Application     *m_instance;
 
 public:


### PR DESCRIPTION
fix crash on WM_KEYDOWN 

Some keys on mechanical keyboards returns 255 on KEYDOWN is as high as traditional ASCII goes. It's the code for a null. For example "Fn" key.