### PR TITLE
get_mouse_delta got removed some time ago.

### DIFF
--- a/csgo/sdk/interfaces/clientdll.h
+++ b/csgo/sdk/interfaces/clientdll.h
@@ -231,7 +231,6 @@ public:
 	virtual void set_timescale( float flTimescale ) = 0;
 	virtual void set_gamestats_data( c_gamestats_data *pGamestatsData ) = 0;
 	virtual c_gamestats_data *get_gamestats_data() = 0;
-	virtual void get_mouse_delta( int &dx, int &dy, bool b ) = 0; // unknown
 	virtual const char *key_lookup_binding_ex( const char *pBinding, int iUserId = -1, int iStartCount = 0,
 	                                         int iAllowJoystick = -1 ) = 0;
 	virtual int key_code_for_binding( char const *, int, int, int ) = 0;


### PR DESCRIPTION
Open up ida and check the 185 vfunc in the engineclient vtable which would be

 virtual c_steam_api_context *get_steam_api_context() = 0;

but in the class its 186. get_mouse_delta got removed some updates ago.

https://i.imgur.com/MtWTIwZ.png