### PR TITLE
Updating filesystem headers

### DIFF
--- a/csgo/configs/configs.cpp
+++ b/csgo/configs/configs.cpp
@@ -1,6 +1,6 @@
 #include "config.h"
 #include "..\json.h"
-#include <experimental/filesystem>
+#include <filesystem>
 
 nlohmann::json json;
 
@@ -48,8 +48,8 @@ void reset_item( item &item ) {
 }
 
 bool c_config::init( ) {
-	if( !std::experimental::filesystem::exists( m_directory ) ) {
-		if( !std::experimental::filesystem::create_directory( m_directory ) ) {
+	if( !std::filesystem::exists( m_directory ) ) {
+		if( !std::filesystem::create_directory( m_directory ) ) {
 			_RPT1( _CRT_WARN, "Failed to create profile directory. Ignoring this error will result in not being able to create or save profiles.\n\n%s", m_directory );
 			return false;
 		}
@@ -256,7 +256,7 @@ void c_config::remove( const std::string &file ) const {
 std::vector< std::string > c_config::get_configs( ) const {
 	std::vector< std::string > output{ };
 
-	for( auto &file_path : std::experimental::filesystem::directory_iterator( m_directory ) ) {
+	for( auto &file_path : std::filesystem::directory_iterator( m_directory ) ) {
 		if( file_path.path( ).string( ).empty( ) )
 			continue;
 

--- a/csgo/menu/menu.cpp
+++ b/csgo/menu/menu.cpp
@@ -5,7 +5,7 @@
 #include "../features/chams/chams.h"
 #include "../features/chaiscript/chai_wrapper.hpp"
 #include "../features/chaiscript/chai_console.hpp"
-#include <experimental/filesystem>
+#include <filesystem>
 
 using namespace controls;
 
@@ -113,7 +113,7 @@ void c_main_form::playerlist_tab( ) { }
 
 std::vector< std::string > get_antiaims( const std::string dir, std::vector< std::string > &vec ) {
 	std::vector< std::string > str_list = vec;
-	for( auto &file_path : std::experimental::filesystem::directory_iterator( dir ) ) {
+	for( auto &file_path : std::filesystem::directory_iterator( dir ) ) {
 		if( file_path.path( ).string( ).empty( ) )
 			continue;
 
@@ -444,7 +444,7 @@ void c_main_form::misc_tab( ) {
 		std::vector< std::string > names = {};
 		std::string dir = "hitsounds";
 
-		for( auto &file_path : std::experimental::filesystem::directory_iterator( dir ) ) {
+		for( auto &file_path : std::filesystem::directory_iterator( dir ) ) {
 			if( !file_path.path( ).string( ).empty( ) ) {
 				if( file_path.path( ).string( ).find( ".wav" ) != std::string::npos )
 					names.emplace_back( file_path.path( ).string( ).erase( 0, dir.length( ) + 1 ) );


### PR DESCRIPTION
Build in VS2019 Enterprise 16.6.4 produced error;

1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.26.28801\include\experimental\filesystem(30,1): fatal error C1189: #error:  The <experimental/filesystem> header providing std::experimental::filesystem is deprecated by Microsoft and will be REMOVED. It is superseded by the C++17 <filesystem> header providing std::filesystem. You can define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING to acknowledge that you have received this warning. (compiling source file csgo\configs\configs.cpp)

Headers and affected functions replaced.